### PR TITLE
ci: bump gradle-build-pr workflow to v2.1.0 and disable tests for BOM

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,7 +3,8 @@ on: [pull_request]
 
 jobs:
   build:
-    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-build-pr.yml@v2.0.0
+    uses: OneLiteFeatherNET/workflows/.github/workflows/gradle-build-pr.yml@v2.1.0
     with:
       java-version: "21"
+      run-tests: false
     secrets: inherit


### PR DESCRIPTION
## Summary
Updated the gradle build PR workflow to use version 2.1.0 and configured it to skip test execution.

## Key Changes
- Upgraded `gradle-build-pr.yml` workflow from v2.0.0 to v2.1.0
- Added `run-tests: false` configuration to disable test execution during PR builds

## Implementation Details
The workflow now leverages the new `run-tests` input parameter available in the v2.1.0 release of the shared gradle build workflow, allowing PR builds to skip the test phase while maintaining Java 21 compatibility.

https://claude.ai/code/session_013iLGeQtY9vtBztCchEiTNC